### PR TITLE
Rename and Enhance Action Trigger Documentation: Add Cloning Steps, Tips and Warnings

### DIFF
--- a/docs/pn-setup-guide/configure-evergreen.md
+++ b/docs/pn-setup-guide/configure-evergreen.md
@@ -1,7 +1,8 @@
 ---
+
 sidebar_position: 4
 ---
-# Create an action trigger
+# Configure Evergreen Action Triggers
 
 This guide is for the Evergreen Administrator.
 It will help you set up your Evergreen (EG) server for sending a push notifications with an action trigger.  It assumes that your System Administrator has already installed the `hemlock-sendmsg` daemon, and it's listening on `localhost:8842`.
@@ -37,7 +38,29 @@ The action trigger uses the CallHTTP reactor to send a request to the hemlock-se
 
 As an EG admin, login to the Staff client and go to Local Administration >> Notifications / Action Triggers.
 
-Procedure:
+Checkout the [Evergreen Action Trigger documentation](https://docs.evergreen-ils.org/docs/latest/admin/actiontriggers.html) for more information.
+
+### Cloning an Existing Action Trigger
+
+:::tip
+Cloning an existing action trigger is a good way to start especially if you are not familiar with action triggers. It is easier to modify an existing action trigger than to create one from scratch and can help reduce errors and save time on troubleshooting.
+ - Make sure that you clone a working action trigger.
+ - Clone an action trigger that uses the same hook as the one you want to create.
+:::
+
+1. Right click an existing event definition and click `Clone Selected` or select the event definition and click `Clone Selected` from the Actions menu.
+2. When prompted to clone the environment, select `Yes`.
+3. Set the reactor to `CallHTTP`.
+4. Set the template according to the [sample template](#sample-template) below.
+
+### Creating an Action Trigger from Scratch
+
+:::warning
+Creating an action trigger from scratch can be tricky as the environment and parameters of action triggers can be complex. Only create an action trigger from scratch if you are certain you can do so.
+:::
+
+This example event definition is for a courtesy notice. Some details may need to be adjusted for your specific use case. It is most important to set the reactor to `CallHTTP` and the template according to the [sample template](#sample-template) below.
+
 * Click `New Event Definition`
 * Set the following form values:
 
@@ -53,13 +76,15 @@ Procedure:
     | Event Repeatability Delay      | 00:00:00                       |
     | Max Event Validity Delay       | -300 days                      |
     | Retention Interval             | 6 mons                         |
-    | Template                       | (see below)                    |
+    | Template                       | [(see below)](#sample-template)          |
     | Context Bib Path               | target_copy.call_number.record |
     | Context Item Path              | target_copy                    |
     | Context Library Path           | circ_lib                       |
     | Context User Path              | usr                            |
 
-* Set the Template form value to
+### Sample Template
+
+Whether cloning an existing action trigger or creating a new one, the template should be set as follows. The parameters `title`, `body`, and `type` will vary depending on the type of notification you want to send.
 
 ```
 method get

--- a/docs/pn-setup-guide/index.md
+++ b/docs/pn-setup-guide/index.md
@@ -13,4 +13,4 @@ Setup involves the following steps (and the following people):
 * [Set up the Firebase project (Mobile App Admin)](setup-firebase-project.md)
 * [Configure the Hemlock app (Mobile App Developer)](configure-hemlock-app.md)
 * [Install the hemlock-sendmsg daemon (Evergreen System Admin)](install-sendmsg-daemon.md)
-* [Create an action trigger (Evergreen Admin)](create-an-action-trigger.md)
+* [Configure Evergreen Action Triggers (Evergreen Admin)](configure-evergreen.md)

--- a/docs/pn-troubleshooting-guide/index.md
+++ b/docs/pn-troubleshooting-guide/index.md
@@ -122,7 +122,7 @@ Ensure that notifications are enabled for the app:
 
 #### "500 Error" after signing in
 <details>
-1. Ensure the User Setting Type is created.  After signing in, the app tries to store the push notification token in the database, and it gets this error if the User Setting Type is missing.  See [Push Notification Setup Guide](../pn-setup-guide/create-an-action-trigger.md).
+1. Ensure the User Setting Type is created.  After signing in, the app tries to store the push notification token in the database, and it gets this error if the User Setting Type is missing.  See [Push Notification Setup Guide](../pn-setup-guide/configure-evergreen.md).
 </details>
 
 ## Additional Notes


### PR DESCRIPTION
> This change came out of Bibliomation's recent struggles to get push notifications set up. The problem ended up being our environment was misconfigured. We could have avoided a lot of pain if we started from a clone of an existing working action trigger instead of starting from scratch. By environment, I am referring to the action trigger's environment, not the general dev or production environment.
![image](https://github.com/user-attachments/assets/f568683f-3cfa-4baa-aa27-d95dc6a1874e)
This change may be more opinionated than my previous ones, so feel free to provide feedback and I can adjust as needed. Though I will say that the Evergreen docs themselves also recommend against creating action triggers from scratch.

Renames the \"create-an-action-trigger.md\" file to \"configure-evergreen.md\" to better reflect its content. Enhances documentation by adding detailed procedures for cloning and creating action triggers with reminders and warnings. Links to a newly added sample template subsection for better guidance.

- Guide title changed to \"Configure Evergreen Action Triggers\"
- Added sections on cloning and creating action triggers from scratch
- Included tips and warnings for best practices
- Provided a link to the Evergreen Action Trigger documentation for additional help